### PR TITLE
Remove specific applciation versions

### DIFF
--- a/blueprints/ember-cli-zesty-app-base/index.js
+++ b/blueprints/ember-cli-zesty-app-base/index.js
@@ -20,18 +20,18 @@ module.exports = {
 
     return blueprint.addAddonsToProject({
       packages: [
-        { name: 'ember-cli-eslint', target: '^2.0.0' },
-        { name: 'ember-cli-template-lint', target: '^0.4.12' },
-        { name: 'ember-concurrency', target: '^0.7.15' },
-        { name: 'ember-test-selectors', target: '^0.0.3' },
-        { name: 'ember-cli-sass', target: '^5.5.0' }
+        { name: 'ember-cli-eslint' },
+        { name: 'ember-cli-template-lint' },
+        { name: 'ember-concurrency' },
+        { name: 'ember-test-selectors' },
+        { name: 'ember-cli-sass' }
       ],
       blueprintOptions: {
         saveDev: true
       }
     }).then(function() {
       return blueprint.addPackagesToProject([
-        { name: 'ember-cli-deploy', target: '^0.6.4' }
+        { name: 'ember-cli-deploy' }
       ])
     }).then(function() {
       safeUnlinkSync(path.join(project.root, '.jscsrc'));


### PR DESCRIPTION
Allow yarn to manage our versions on a project by project basis.

E.g. use yarn upgrade

cc @mmun, @halfdan